### PR TITLE
fix import issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {
     JSONIsFrequency,
     JSONinterval,
     randomElement,
-  } from "./helpers.js";
+  } from "./helpers";
   
   import * as fs from 'fs';
   import * as path from 'path';


### PR DESCRIPTION
Importing JavaScript files without specifying the file extension is allowed by default, but the file extension should be '.ts', not '.js'.